### PR TITLE
Remove LoadEnviron

### DIFF
--- a/luaApp/src/luaEpics.cpp
+++ b/luaApp/src/luaEpics.cpp
@@ -10,6 +10,8 @@
 #endif
 
 
+#include "osiEnviron.h"
+
 #include <macLib.h>
 
 #define epicsExportSharedSymbols
@@ -173,26 +175,4 @@ epicsShareFunc void luaLoadMacros(lua_State* state, const char* macro_list)
 			lua_setglobal(state, pairs[0]);
 		}
 	}
-}
-
-
-epicsShareFunc void luaLoadEnviron(lua_State* state)
-{
-	#if defined(__unix__)
-	extern char** environ;
-	char** sp;
-	
-	for (sp = environ; (sp != NULL) && (*sp != NULL); sp++)
-	{
-		std::string line(*sp);
-		
-		size_t split_loc = line.find_first_of("=");
-		
-		std::string var_name = line.substr(0, split_loc);
-		std::string var_val  = line.substr(split_loc + 1);
-		
-		lua_pushstring(state, var_val.c_str());
-		lua_setglobal(state, var_name.c_str());
-	}
-	#endif
 }

--- a/luaApp/src/luaEpics.cpp
+++ b/luaApp/src/luaEpics.cpp
@@ -9,9 +9,6 @@
 	#include <sysSymTbl.h>
 #endif
 
-
-#include "osiEnviron.h"
-
 #include <macLib.h>
 
 #define epicsExportSharedSymbols

--- a/luaApp/src/luaEpics.h
+++ b/luaApp/src/luaEpics.h
@@ -16,5 +16,4 @@ epicsShareFunc int luaLoadScript(lua_State* state, const char* script_file);
 epicsShareFunc int luaLoadString(lua_State* state, const char* lua_code);
 epicsShareFunc int  luaLoadParams(lua_State* state, const char* param_list);
 epicsShareFunc void luaLoadMacros(lua_State* state, const char* macro_list);
-epicsShareFunc void luaLoadEnviron(lua_State* state);
 #endif

--- a/luaApp/src/luaShell.cpp
+++ b/luaApp/src/luaShell.cpp
@@ -353,7 +353,6 @@ epicsShareFunc int epicsShareAPI luashBegin(const char* pathname, const char* ma
 {
 	lua_State* state = luaL_newstate();
 	luaL_openlibs(state);
-	luaLoadEnviron(state);
 	
 	lua_pushlightuserdata(state, *iocshPpdbbase);
 	lua_setglobal(state, "pdbbase");


### PR DESCRIPTION
posix systems are the only ones that have a full list of everything in the environment. In order to keep similarities between systems the same, copying the environment into global variables shouldn't be something that only happens sometimes. Instead, every architecture should just use the os.getenv command to get environmental variables.