### PR TITLE
Added static library registration function

### DIFF
--- a/luaApp/src/luaEpics.cpp
+++ b/luaApp/src/luaEpics.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <cstdio>
 #include <cstdlib>
+#include <vector>
 
 #if defined(__vxworks) || defined(vxWorks)
 	#include <symLib.h>
@@ -13,6 +14,8 @@
 
 #define epicsExportSharedSymbols
 #include "luaEpics.h"
+
+static std::vector<std::pair<const char*, lua_CFunction> > registered;
 
 epicsShareFunc std::string luaLocateFile(std::string filename)
 {
@@ -171,5 +174,22 @@ epicsShareFunc void luaLoadMacros(lua_State* state, const char* macro_list)
 			
 			lua_setglobal(state, pairs[0]);
 		}
+	}
+}
+
+epicsShareFunc void luaRegisterLibrary(const char* library_name, lua_CFunction library_func)
+{
+	std::pair<const char*, lua_CFunction> temp(library_name, library_func);
+	
+	registered.push_back(temp);
+}
+
+epicsShareFunc void luaLoadRegisteredLibraries(lua_State* state)
+{
+	for (std::size_t index = 0; index < registered.size(); index += 1)
+	{
+		std::pair<const char* , lua_CFunction> temp = registered[index];
+		
+		luaL_requiref( state, temp.first, temp.second, 1 );
 	}
 }

--- a/luaApp/src/luaEpics.h
+++ b/luaApp/src/luaEpics.h
@@ -16,4 +16,7 @@ epicsShareFunc int luaLoadScript(lua_State* state, const char* script_file);
 epicsShareFunc int luaLoadString(lua_State* state, const char* lua_code);
 epicsShareFunc int  luaLoadParams(lua_State* state, const char* param_list);
 epicsShareFunc void luaLoadMacros(lua_State* state, const char* macro_list);
+
+epicsShareFunc void luaRegisterLibrary(const char* library_name, lua_CFunction load_func);
+epicsShareFunc void luaLoadRegisteredLibraries(lua_State* state);
 #endif

--- a/luaApp/src/luaShell.cpp
+++ b/luaApp/src/luaShell.cpp
@@ -353,6 +353,7 @@ epicsShareFunc int epicsShareAPI luashBegin(const char* pathname, const char* ma
 {
 	lua_State* state = luaL_newstate();
 	luaL_openlibs(state);
+	luaLoadRegisteredLibraries(state);
 	
 	lua_pushlightuserdata(state, *iocshPpdbbase);
 	lua_setglobal(state, "pdbbase");


### PR DESCRIPTION
This updates the luaEpics files to allow users to register a lua module within code that will be statically linked into the final application.

The function luaRegisterLibrary takes in a name for the library and a function with the signature:  
`int (*lua_CFunction) (lua_State *L);`

When the lua shell is run, all functions currently registered are run. If those functions push a value onto the stack, the top value is given the name of the library. So, using lua's newlib function, you can bind functions like so:

    static int l_bar( lua_State *L )
    {
        lua_pushstring(L, "Hello, World");
        return 1;
    }

    int luaopen_foo( lua_State *L )
    {
        static const luaL_Reg foo[] = {
            { "bar", l_bar },
            { NULL, NULL }
        };

        luaL_newlib( L, foo );
        return 1;
    }

Then, if you later run the luaRegisterLibrary function:

`luaRegisterLibrary("foo", luaopen_foo);`

you'll be able to run foo.bar() within the lua shell and it will return the value "Hello, World".

Recommended use of the luaRegisterLibrary function is to add it into a dbd registrar function like so:

**foo.cpp**  

    static void testRegister(void)
    {
        luaRegisterLibrary("test", luaopen_test);
    }

    epicsExportRegistrar(testRegister);

**foo.dbd**

    registrar(testRegister)


Then, the libraries will automatically register when you load the IOC's dbd file.