### PR TITLE
Fix compilation error on Windows VS2015

### DIFF
--- a/luaApp/src/rec/luascriptRecord.cpp
+++ b/luaApp/src/rec/luascriptRecord.cpp
@@ -291,7 +291,7 @@ static long loadNumbers(luascriptRecord* record)
 template <typename T>
 static int createTable(lua_State* state, DBLINK* field, short field_type, long* elements, bool integers)
 {
-	T data[*elements];
+	T *data = new T[*elements];
 	int status = dbGetLink(field, field_type, data, 0, elements);
 	
 	if (status) { return status; }
@@ -306,6 +306,7 @@ static int createTable(lua_State* state, DBLINK* field, short field_type, long* 
 		lua_rawseti(state, -2, elem + 1);
 	}
 	
+	delete data;
 	return 0;
 }
 


### PR DESCRIPTION
luscriptRecord.cpp fails to compile on Visual Studio 2015.

```
make[3]: Entering directory 'J:/epics/devel/lua/luaApp/src/O.windows-x64-static'
cl -EHsc -GR           -DUSE_TYPED_RSET     -nologo -FC -D__STDC__=0 -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE   -Ox -Oy-   -W3 -w44355 -w44344 -w44251     -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING    -MT  -TP  -I. -I../O.Common -I. -I. -I.. -I../../../luaApp/src/core -I../../../luaApp/src/devSupport -I../../../luaApp/src/rec -I../../../luaApp/src/shell -I../../../luaApp/src/libs -I../../../include/compiler/msvc -I../../../include/os/WIN32 -I../../../include   -IJ:/epics/devel/include   -IJ:/epics/devel/asyn-4-39/include -IH:/epics-devel/base-7.0.3.1/include/compiler/msvc -IH:/epics-devel/base-7.0.3.1/include/os/WIN32 -IH:/epics-devel/base-7.0.3.1/include        -c ../../../luaApp/src/rec/luascriptRecord.cpp
luascriptRecord.cpp
j:\epics\devel\lua\luaapp\src\rec\luascriptrecord.cpp(629): warning C4800: 'double': forcing value to bool 'true' or 'false' (performance warning)
j:\epics\devel\lua\luaapp\src\rec\luascriptrecord.cpp(294): error C2131: expression did not evaluate to a constant
j:\epics\devel\lua\luaapp\src\rec\luascriptrecord.cpp(294): note: failure was caused by non-constant arguments or reference to a non-constant symbol
j:\epics\devel\lua\luaapp\src\rec\luascriptrecord.cpp(294): note: see usage of 'elements'
j:\epics\devel\lua\luaapp\src\rec\luascriptrecord.cpp(354): note: see reference to function template instantiation 'int createTable<epicsUInt8>(lua_State *,DBLINK *,short,long *,bool)' being compiled
make[3]: *** [H:/epics-devel/base-7.0.3.1/configure/RULES_BUILD:249: luascriptRecord.obj] Error 2
m
```

This pull request fixes the problem.
