### PR TITLE
Remove the duplicated CHECK_RELEASE

### DIFF
--- a/configure/Makefile
+++ b/configure/Makefile
@@ -4,10 +4,6 @@ TOP=..
 
 include $(TOP)/configure/CONFIG
 
-# Set the following to NO to disable consistency checking of
-# the support applications defined in $(TOP)/configure/RELEASE
-CHECK_RELEASE = YES
-
 TARGETS = $(CONFIG_TARGETS)
 CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
 


### PR DESCRIPTION
Hi @keenanlang 

This pull request contains a logic fix which allows users to configure `CHECK_RELEASE` in `configure/CONFIG_SITE` dynamically. 

Please look at it, and let me know. 

@jeonghanlee 